### PR TITLE
Pass resource to ResourceConfig instance

### DIFF
--- a/src/Settings/HasSettings.php
+++ b/src/Settings/HasSettings.php
@@ -57,6 +57,7 @@ trait HasSettings
         }
 
         $settingsConfig = $this->getSettingsConfig();
+        $settingsConfig->setResource($this);
 
         return $this->settings = new Settings($settingsConfig, $this);
     }

--- a/src/Settings/ResourceConfig.php
+++ b/src/Settings/ResourceConfig.php
@@ -2,8 +2,41 @@
 
 namespace LaravelPropertyBag\Settings;
 
+use Illuminate\Database\Eloquent\Model;
+
 class ResourceConfig
 {
+    /**
+     * Resource that has settings.
+     *
+     * @var Model
+     */
+    protected $resource;
+
+    /**
+     * Sets resource.
+     *
+     * @param Model $resource.
+     *
+     * @return this
+     */
+    public function setResource(Model $resource)
+    {
+        $this->resource = $resource;
+
+        return $this;
+    }
+
+    /**
+     * Returns resource.
+     *
+     * @return Model
+     */
+    public function getResource()
+    {
+        return $this->resource;
+    }
+
     /**
      * Return a collection of registered settings.
      *

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -72,6 +72,16 @@ class Settings
     }
 
     /**
+     * Get resource config.
+     *
+     * @return ResourceConfig
+     */
+    public function getResourceConfig()
+    {
+        return $this->settingsConfig;
+    }
+
+    /**
      * Get registered settings.
      *
      * @return Collection

--- a/tests/Unit/SettingsTest.php
+++ b/tests/Unit/SettingsTest.php
@@ -3,8 +3,10 @@
 namespace LaravelPropertyBag\tests\Unit;
 
 use Illuminate\Support\Collection;
-use LaravelPropertyBag\tests\TestCase;
+use LaravelPropertyBag\Settings\ResourceConfig;
 use LaravelPropertyBag\Settings\Settings;
+use LaravelPropertyBag\tests\Classes\User;
+use LaravelPropertyBag\tests\TestCase;
 
 class SettingsTest extends TestCase
 {
@@ -37,6 +39,22 @@ class SettingsTest extends TestCase
         $this->assertInstanceOf(Collection::class, $registered);
 
         $this->assertCount(17, $registered->flatten());
+    }
+
+    /**
+     * @test
+     */
+    public function resource_config_can_access_orignal_model()
+    {
+        $resourceConfig = $this->user->settings()->getResourceConfig();
+
+        $this->assertInstanceOf(ResourceConfig::class, $resourceConfig);
+
+        $resource = $resourceConfig->getResource();
+
+        $this->assertInstanceOf(User::class, $resource);
+
+        $this->assertEquals($this->user->id, $resource->id);
     }
 
     /**


### PR DESCRIPTION
This patch allows `ResourceConfig` to access original model while building registered settings.

This might be helpful while working with models that should have different settings (depending on instance's attribute value, as example).