### PR TITLE
Store failed key name in InvalidSettingsValue exception instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ $value = $model->settings()->get($key);
 ##### set($array)
 Set array keys to associated values. Values may be of any type. Returns Settings.    
 **When a default value is passed to set(), it will not be stored in the database.** Don't be alarmed if your default values aren't showing up in the table.           
-If a value is not registered in the allowed values array, a LaravelPropertyBag\Exceptions\InvalidSettingsValue exception will be thrown.
+If a value is not registered in the allowed values array, a `LaravelPropertyBag\Exceptions\InvalidSettingsValue` exception will be thrown. You can use `$e->getFailedKey()` method to retrieve failed setting name.
 ```php
 $model->settings()->set([
   'key1' => 'value1',

--- a/src/Exceptions/InvalidSettingsValue.php
+++ b/src/Exceptions/InvalidSettingsValue.php
@@ -7,6 +7,13 @@ use Exception;
 class InvalidSettingsValue extends Exception
 {
     /**
+     * Failed key name.
+     *
+     * @var string
+     */
+    protected $failedKey;
+
+    /**
      * Setting value is not definied in key's allowed values array.
      *
      * @param string $key
@@ -15,6 +22,32 @@ class InvalidSettingsValue extends Exception
      */
     public static function settingNotAllowed($key)
     {
-        return new static("Given value is not a registered allowed value for {$key}.");
+        $exception = new static("Given value is not a registered allowed value for {$key}.");
+
+        return $exception->setFailedKey($key);
+    }
+
+    /**
+     * Sets failed key name.
+     *
+     * @param string $key
+     *
+     * @return static
+     */
+    public function setFailedKey($key)
+    {
+        $this->failedKey = $key;
+
+        return $this;
+    }
+
+    /**
+     * Returns failed key name.
+     *
+     * @return string
+     */
+    public function getFailedKey()
+    {
+        return $this->failedKey;
     }
 }

--- a/tests/Unit/SettingsTest.php
+++ b/tests/Unit/SettingsTest.php
@@ -3,10 +3,11 @@
 namespace LaravelPropertyBag\tests\Unit;
 
 use Illuminate\Support\Collection;
-use LaravelPropertyBag\Settings\ResourceConfig;
+use LaravelPropertyBag\tests\TestCase;
 use LaravelPropertyBag\Settings\Settings;
 use LaravelPropertyBag\tests\Classes\User;
-use LaravelPropertyBag\tests\TestCase;
+use LaravelPropertyBag\Settings\ResourceConfig;
+use LaravelPropertyBag\Exceptions\InvalidSettingsValue;
 
 class SettingsTest extends TestCase
 {
@@ -391,6 +392,22 @@ class SettingsTest extends TestCase
         $this->user->settings()->set([
             'test_settings1' => 'invalid',
         ]);
+    }
+
+    /**
+     * @test
+     */
+    public function invalid_setting_value_exception_should_contain_failed_key_name()
+    {
+        $this->actingAs($this->user);
+
+        try {
+            $this->user->settings()->set([
+                'test_settings1' => 'invalid',
+            ]);
+        } catch (InvalidSettingsValue $e) {
+            $this->assertEquals('test_settings1', $e->getFailedKey());
+        }
     }
 
     /**


### PR DESCRIPTION
This may be useful when you need to know what exact key failed in validation process while updating a lot of setting values.

For example, user submits form with settings and some field in payload has wrong value. Currently there's no way to display friendly message and point to specific form field.