### PR TITLE
Reduce SQL queries by utilizing eagerly loaded propertyBag relation

### DIFF
--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -233,6 +233,14 @@ class Settings
             $this->setKeyValue($key, $value);
         });
 
+        // If we were working with eagerly-loaded relation,
+        // we need to reload its data to be sure that we
+        // are working only with the actual settings.
+
+        if ($this->resource->relationLoaded('propertyBag')) {
+            $this->resource->load('propertyBag');
+        }
+
         return $this->sync();
     }
 
@@ -396,8 +404,6 @@ class Settings
      */
     protected function sync()
     {
-        $this->resource->load('propertyBag');
-
         $this->settings = $this->getAllSettingsFlat();
     }
 
@@ -420,6 +426,10 @@ class Settings
      */
     protected function getAllSettings()
     {
+        if ($this->resource->relationLoaded('propertyBag')) {
+            return $this->resource->propertyBag;
+        }
+
         return $this->propertyBag()
             ->where('resource_id', $this->resource->id)
             ->get();

--- a/tests/Unit/SettingsTest.php
+++ b/tests/Unit/SettingsTest.php
@@ -532,4 +532,93 @@ class SettingsTest extends TestCase
 
         $this->assertEquals('monkey', $this->user->settings('test_settings1'));
     }
+
+    /**
+     * @test
+     */
+    public function created_setting_is_immediately_available_for_reading()
+    {
+        $settings = $this->user->settings();
+
+        $this->assertEquals(false, $settings->get('test_settings3'));
+
+        $settings->set(['test_settings3' => true]);
+        $this->assertEquals(true, $settings->get('test_settings3'));
+    }
+
+    /**
+     * @test
+     */
+    public function updated_setting_is_immediately_available_for_reading()
+    {
+        $settings = $this->user->settings();
+
+        $settings->set(['test_settings1' => 'bananas']);
+        $this->assertEquals('bananas', $settings->get('test_settings1'));
+
+        $settings->set(['test_settings1' => 'grapes']);
+        $this->assertEquals('grapes', $settings->get('test_settings1'));
+    }
+
+    /**
+     * @test
+     */
+    public function deleted_setting_is_immediately_available_for_reading()
+    {
+        $settings = $this->user->settings();
+
+        $this->assertEquals('monkey', $settings->get('test_settings1'));
+
+        $settings->set(['test_settings1' => 'grapes']);
+        $this->assertEquals('grapes', $settings->get('test_settings1'));
+
+        $settings->set(['test_settings1' => 'monkey']);
+        $this->assertEquals('monkey', $settings->get('test_settings1'));
+    }
+
+    /**
+     * @test
+     */
+    public function created_setting_is_immediately_available_for_reading_with_preloaded_relation()
+    {
+        $this->user->load('propertyBag');
+        $settings = $this->user->settings();
+
+        $this->assertEquals(false, $settings->get('test_settings3'));
+
+        $settings->set(['test_settings3' => true]);
+        $this->assertEquals(true, $settings->get('test_settings3'));
+    }
+
+    /**
+     * @test
+     */
+    public function updated_setting_is_immediately_available_for_reading_with_preloaded_relation()
+    {
+        $this->user->load('propertyBag');
+        $settings = $this->user->settings();
+
+        $settings->set(['test_settings1' => 'bananas']);
+        $this->assertEquals('bananas', $settings->get('test_settings1'));
+
+        $settings->set(['test_settings1' => 'grapes']);
+        $this->assertEquals('grapes', $settings->get('test_settings1'));
+    }
+
+    /**
+     * @test
+     */
+    public function deleted_setting_is_immediately_available_for_reading_with_preloaded_relation()
+    {
+        $this->user->load('propertyBag');
+        $settings = $this->user->settings();
+
+        $this->assertEquals('monkey', $settings->get('test_settings1'));
+
+        $settings->set(['test_settings1' => 'grapes']);
+        $this->assertEquals('grapes', $settings->get('test_settings1'));
+
+        $settings->set(['test_settings1' => 'monkey']);
+        $this->assertEquals('monkey', $settings->get('test_settings1'));
+    }
 }


### PR DESCRIPTION
Sometimes we need to read settings of multiple models at once - Eloquent's eager loading feature is life saver in those situations. Unfortunately at this time property-bag does not support it.
Furthermore, it loads data from DB twice: at first - from `Settings::sync` method and at second - from `Settings::getAllSettings` method.

Since instantiating `Settings` class performs initial synchronization, we have +2 queries for each model we're working with - even if we explicitly loaded `propertyBag` relation via Eloquent's `with` method.

This PR removes `$this->resource->load('propertyBag');` line from `Settings::sync` method and adds check for loaded `propertyBag` relation in `Settings::getAllSettings` method.

Besides, when user updates settings of resource that have eagerly loaded `propertyBag` relation, `Setting::set` method will reload `propertyBag` relation to make sure that we're wokring only with actual settings.

I've added new tests to be sure that user is able to read updated setting's value when working with & without eagerly loaded relation.