### PR TITLE
Support uncommon primary keys for models

### DIFF
--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -394,7 +394,7 @@ class Settings
     protected function getByKey($key)
     {
         return $this->propertyBag()
-            ->where('resource_id', $this->resource->id)
+            ->where('resource_id', $this->resource->getKey())
             ->where('key', $key)
             ->first();
     }
@@ -431,7 +431,7 @@ class Settings
         }
 
         return $this->propertyBag()
-            ->where('resource_id', $this->resource->id)
+            ->where('resource_id', $this->resource->getKey())
             ->get();
     }
 


### PR DESCRIPTION
If you have a Model with an uncommon primary key, you won't be able to use this package because it directly depends on `id`. Instead of that, I replaced it with `resource->getKey()` which gets the value of whichever primary key the Model has defined.