### PR TITLE
Feature related to #21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 .env
 composer.lock
+.idea

--- a/README.md
+++ b/README.md
@@ -241,6 +241,14 @@ Reset key to default value.
 $default = $model->settings()->reset($key);
 ```
 
+##### withSetting($key, $value = null)
+Get an array with all stored rows with a given setting and/or value.
+```
+$collection = $model::withSetting($key);
+// or
+$collection = $model::withSetting($key, $value);
+```
+
 ### Validation Rules
 Rather than hardcoding values in an array, it is also possible to define rules that determine whether a setting value is valid. Rules are always strings and must contain a colon at both the beginning and ending of the string.
 ```php

--- a/src/Settings/HasSettings.php
+++ b/src/Settings/HasSettings.php
@@ -173,11 +173,12 @@ trait HasSettings
      */
     public static function withSetting($key, $value = null)
     {
-        return static::all()->filter(function($row) use ($key, $value) {
+        return static::all()->filter(function ($row) use ($key, $value) {
             $setting = $row->settings($key);
             if (!is_null($value)) {
                 return !is_null($setting) && $setting === $value;
             }
+            
             return !is_null($setting);
         });
     }

--- a/src/Settings/HasSettings.php
+++ b/src/Settings/HasSettings.php
@@ -178,7 +178,7 @@ trait HasSettings
             if (!is_null($value)) {
                 return !is_null($setting) && $setting === $value;
             }
-            
+
             return !is_null($setting);
         });
     }

--- a/src/Settings/HasSettings.php
+++ b/src/Settings/HasSettings.php
@@ -162,4 +162,23 @@ trait HasSettings
 
         return $this->settings()->allAllowed();
     }
+
+    /**
+     * Get an array with all stored rows with a given setting and/or value.
+     *
+     * @param $key
+     * @param null $value
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public static function withSetting($key, $value = null)
+    {
+        return static::all()->filter(function($row) use ($key, $value) {
+            $setting = $row->settings($key);
+            if (!is_null($value)) {
+                return !is_null($setting) && $setting === $value;
+            }
+            return !is_null($setting);
+        });
+    }
 }

--- a/tests/Unit/HasSettingsTest.php
+++ b/tests/Unit/HasSettingsTest.php
@@ -141,4 +141,24 @@ class HasSettingsTest extends TestCase
 
         $this->assertEquals($actual, $allowed->all());
     }
+
+    /**
+     * @test
+     */
+    public function all_resources_with_setting_can_be_retrieved_from_hassettings()
+    {
+        $collection = $this->user::withSetting('test_settings1');
+
+        $this->assertCount(1, $collection);
+    }
+
+    /**
+     * @test
+     */
+    public function all_resources_with_setting_and_value_can_be_retrieved_from_hassettings()
+    {
+        $collection = $this->user::withSetting('test_settings1', 'monkey');
+
+        $this->assertCount(1, $collection);
+    }
 }


### PR DESCRIPTION
This pull request has a simple implementation for a feature related to #21. 
Some examples below:
`YourModel::withSetting('music_notifications'); ` // returns a collection of YourModel with a specific setting
or 
`YourModel::withSetting('music_notifications', true); ` // returns a collection of YourModel with a specific setting and value
`YourModel` must have the HasSettings trait, so you could use it like this:
`$userCollection = User::withSetting('music_notifications');`